### PR TITLE
Add IPv6 support

### DIFF
--- a/ipam/client/tests/data/db.sql
+++ b/ipam/client/tests/data/db.sql
@@ -79,6 +79,8 @@ INSERT INTO "subnets" VALUES (2,'167903232','29',2,'TEST FULL /29 SUBNET',0,0,1,
 INSERT INTO "subnets" VALUES (3,'167968768','30',2,'TST /30 SUBNET',0,0,1,10,0,'{"2":"1","3":"1"}',0,0,NULL);
 INSERT INTO "subnets" VALUES (4,'168034304','31',2,'TEST /31 SUBNET GROUP',0,0,1,0,0,'{"2":"1","3":"1"}',0,0,NULL);
 INSERT INTO "subnets" VALUES (5,'168099840','31',2,'TEST /31 SUBNET GROUP',0,0,1,10,0,'{"2":"1","3":"1"}',0,0,NULL);
+INSERT INTO "subnets" VALUES (6,'42540488161975842760550356425300246592','125',2,'TEST IPv6 /126 SUBNET',0,0,1,10,0,'{"2":"1","3":"1"}',0,0,NULL);
+INSERT INTO "subnets" VALUES (7,'42540488161975842760550356425300246608','127',2,'TEST IPv6 /127 SUBNET',0,0,1,10,0,'{"2":"1","3":"1"}',0,0,NULL);
 CREATE INDEX "subnets_subnet" ON "subnets" ("subnet");
 CREATE INDEX "sections_id" ON "sections" ("id");
 CREATE INDEX "ipaddresses_dns_name" ON "ipaddresses" ("dns_name");

--- a/ipam/client/tests/test_phpipam.py
+++ b/ipam/client/tests/test_phpipam.py
@@ -143,6 +143,115 @@ def test_add_next_ip(testphpipam):
         testphpipam.add_next_ip(subnet, 'err', 'err')
     assert "is full" in str(excinfo.value)
 
+    subnet = IPNetwork('2001::40/125')
+    description = 'add_next_ip generated ip 19'
+    dnsname = 'add_next_ip generated-ip-19'
+    ipaddr = IPAddress('2001::41')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 20'
+    dnsname = 'add_next_ip generated-ip-20'
+    ipaddr = IPAddress('2001::42')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 21'
+    dnsname = 'add_next_ip generated-ip-21'
+    ipaddr = IPAddress('2001::43')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 22'
+    dnsname = 'add_next_ip generated-ip-22'
+    ipaddr = IPAddress('2001::44')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 23'
+    dnsname = 'add_next_ip generated-ip-21'
+    ipaddr = IPAddress('2001::45')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 24'
+    dnsname = 'add_next_ip generated-ip-22'
+    ipaddr = IPAddress('2001::46')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 25'
+    dnsname = 'add_next_ip generated-ip-22'
+    ipaddr = IPAddress('2001::47')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 125
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    with pytest.raises(ValueError) as excinfo:
+        testphpipam.add_next_ip(subnet, 'err', 'err')
+    assert "is full" in str(excinfo.value)
+
+    subnet = IPNetwork('2001::50/127')
+    description = 'add_next_ip generated ip 26'
+    dnsname = 'add_next_ip generated-ip-23'
+    ipaddr = IPAddress('2001::50')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 127
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    description = 'add_next_ip generated ip 27'
+    dnsname = 'add_next_ip generated-ip-24'
+    ipaddr = IPAddress('2001::51')
+    ip = testphpipam.add_next_ip(subnet, dnsname, description)
+    assert ip.ip == ipaddr
+    assert ip.prefixlen == 127
+    testip = testphpipam.get_ip_by_desc(description)
+    assert testip['ip'] == ipaddr
+    assert testip['dnsname'] == dnsname
+    assert testip['description'] == description
+
+    with pytest.raises(ValueError) as excinfo:
+        testphpipam.add_next_ip(subnet, 'err', 'err')
+    assert "is full" in str(excinfo.value)
+
 
 def test_get_next_free_ip(testphpipam):
     ip = testphpipam.get_next_free_ip(IPNetwork('10.1.0.0/28'))

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 setup(
     name='ipam-client',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    version='0.1',
+    version='0.2',
     description='IPAM abstraction layer library',
     author='Criteo',
     author_email='github@criteo.com',
     url='https://github.com/criteo/ipam-client',
-    download_url='https://github.com/criteo/ipam-client/archive/v0.1.tar.gz',
+    download_url='https://github.com/criteo/ipam-client/archive/v0.2.tar.gz',
     keywords=['ipam', 'phpipam'],
     license='Apache',
     classifiers=[


### PR DESCRIPTION
To do this, remove legacy calls to struct and socket as netaddr
supports int() correctly now.

Also, add correct quoting around %d params to reflect phpipam's schema.

Signed-off-by: Damien Claisse <d.claisse@criteo.com>