### PR TITLE
Improve speed on get_next_free_ip + bump version

### DIFF
--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -137,9 +137,8 @@ class PHPIPAM(AbstractIPAM):
                 return ip_interface("%s/%d" % (candidate_ip,
                                                subnet.prefixlen))
         raise ValueError("Subnet %s/%s is full"
-                            % (subnet.network_address,
-                               subnet.prefixlen))
-
+                         % (subnet.network_address,
+                            subnet.prefixlen))
 
     def get_allocated_ips_by_subnet_id(self, subnetid):
         self.cur.execute("SELECT ip_addr FROM ipaddresses \

--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -128,25 +128,18 @@ class PHPIPAM(AbstractIPAM):
                              "for subnet %s/%s"
                              % (subnet.network_address,
                                 subnet.prefixlen))
-        # Create hosts list in subnet
-        subnetips = subnet.hosts()
         # Get allocated ip addresses from database
         usedips = self.get_allocated_ips_by_subnet_id(subnetid)
 
-        subnetips = set(subnetips)
-        usedips = set(usedips)
-        # Compute the difference between sets, aka available ip addresses set
-        availableips = subnetips.difference(usedips)
-        # Make a list from the set so we can sort it
-        availableips = list(availableips)
-        availableips.sort()
-        if len(availableips) <= 0:
-            raise ValueError("Subnet %s/%s is full"
-                             % (subnet.network_address,
-                                subnet.prefixlen))
-        # Return first available ip address in the list
-        return ip_interface("%s/%d" % (availableips[0],
-                                       subnet.prefixlen))
+        for candidate_ip in subnet.hosts():
+            if candidate_ip not in usedips:
+                # Return first available ip address in the subnet
+                return ip_interface("%s/%d" % (candidate_ip,
+                                               subnet.prefixlen))
+        raise ValueError("Subnet %s/%s is full"
+                            % (subnet.network_address,
+                               subnet.prefixlen))
+
 
     def get_allocated_ips_by_subnet_id(self, subnetid):
         self.cur.execute("SELECT ip_addr FROM ipaddresses \

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 setup(
     name='ipam-client',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    version='0.3.1',
+    version='0.3.2',
     description='IPAM abstraction layer library',
     author='Criteo',
     author_email='github@criteo.com',
     url='https://github.com/criteo/ipam-client',
-    download_url='https://github.com/criteo/ipam-client/archive/v0.3.1.tar.gz',
+    download_url='https://github.com/criteo/ipam-client/archive/v0.3.2.tar.gz',
     keywords=['ipam', 'phpipam'],
     license='Apache',
     classifiers=[


### PR DESCRIPTION
Useful for big /64 IPv6 subnets : we do not list all subnet hosts then
diff between available IPs and used IPs but rather try to find the first available IP that
is not in used IPs.