### PR TITLE
Improve speed on get_next_free_ip + bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 setup(
     name='ipam-client',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    version='0.3.1',
+    version='0.3.2',
     description='IPAM abstraction layer library',
     author='Criteo',
     author_email='github@criteo.com',
     url='https://github.com/criteo/ipam-client',
-    download_url='https://github.com/criteo/ipam-client/archive/v0.3.1.tar.gz',
+    download_url='https://github.com/criteo/ipam-client/archive/v0.3.2.tar.gz',
     keywords=['ipam', 'phpipam'],
     license='Apache',
     classifiers=[


### PR DESCRIPTION
Useful for big /64 IPv6 subnets : we do not list all subnet hosts then
diff between available IPs and used IPs but rather try to find the first available IP that
is not in used IPs.