### PR TITLE
Directly delete IP addresses in delete_subnet

### DIFF
--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -400,15 +400,6 @@ class PHPIPAM(AbstractIPAM):
                              % (ipaddress.ip, subnetid))
         return True
 
-    def _empty_subnet(self, subnet_id):
-        """
-        Delete all IP addresses within a subnet
-        """
-        with MySQLLock(self):
-            self.cur.execute("DELETE FROM ipaddresses \
-                             WHERE subnetId = %d"
-                             % subnet_id)
-
     def delete_subnet(self, subnet, empty_subnet=False):
         """
         Delete a subnet in IPAM. subnet must be an
@@ -422,7 +413,9 @@ class PHPIPAM(AbstractIPAM):
             if ip_list:
                 # We have IP addresses in our subnet
                 if empty_subnet:
-                    self._empty_subnet(subnet_id)
+                    self.cur.execute("DELETE FROM ipaddresses \
+                                     WHERE subnetId = %d"
+                                     % subnet_id)
                 else:
                     raise ValueError("Subnet %s/%s is not empty"
                                      % (subnet.network_address,


### PR DESCRIPTION
Due to the MySQL lock, it was not possible to delete a subnet and empty it at the same time.
As `_empty_subnet()` was only called by `delete_subnet()`, the function is removed and the code directly integrated in `delete_subnet()`.