### PR TITLE
Limit rows when checking if IP already exists

### DIFF
--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -126,7 +126,7 @@ class PHPIPAM(AbstractIPAM):
         with MySQLLock(self):
             subnetid = self.find_subnet_id(ipaddress)
             self.cur.execute("SELECT ip_addr FROM ipaddresses \
-                             WHERE ip_addr='%d' AND subnetId=%d"
+                             WHERE ip_addr='%d' AND subnetId=%d LIMIT 1"
                              % (ipaddress.ip, subnetid))
             row = self.cur.fetchone()
             if row is not None:


### PR DESCRIPTION
Fixes the "Unread result found" error : as the _SELECT_ operation may return multiple rows and `self.cur.fetchone()` only reads 1 result, an exception could occur (if one same `ip_addr` is present with multiple `subnetId`).