### PR TITLE
Make `_get_version()` more reliable

### DIFF
--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -99,12 +99,11 @@ class PHPIPAM(AbstractIPAM):
         self.set_section_id(row[0])
 
     def _get_version(self):
-        with MySQLLock(self):
-            self.cur.execute('SELECT version FROM settings')
-            row = self.cur.fetchone()
-            if row is None:
-                raise ValueError('Could not retrieve version from DB')
-            return float(row[0])
+        self.cur.execute('SELECT version FROM settings LIMIT 1')
+        row = self.cur.fetchone()
+        if row is None:
+            raise ValueError('Could not retrieve version from DB')
+        return float(row[0])
 
     def get_section_id(self):
         return self.section_id


### PR DESCRIPTION
Add a limit to the SQL query to avoid "unread result found" in case the DB has 2 entries (which is not normal).
Also remove the unnecessary lock as we just perform a simple read.