### PR TITLE
read results after lock release

### DIFF
--- a/ipam/client/backends/phpipam.py
+++ b/ipam/client/backends/phpipam.py
@@ -43,6 +43,8 @@ class MySQLLock(object):
                 self.ipam.db.commit()
             self.ipam.cur.execute('SELECT RELEASE_LOCK("{}")'.format(
                 LOCK_NAME))
+            # empty cursor to avoid "unread results" error
+            self.ipam.cur.fetchall()
             self.ipam.db.autocommit = True
 
 


### PR DESCRIPTION
The `SELECT RELEASE_LOCK` seems to return results that are not read which trigger the "unread result" error when using functions legitimately.